### PR TITLE
s/TokenEOF/tokenEOF

### DIFF
--- a/lisp1_5/lex.go
+++ b/lisp1_5/lex.go
@@ -19,7 +19,7 @@ type TokType int
 
 const (
 	tokenError TokType = iota
-	TokenEOF
+	tokenEOF
 	tokenAtom
 	tokenConst
 	tokenNumber
@@ -132,7 +132,7 @@ func (l *lexer) next() *token {
 		case r == ';':
 			l.skipToNewline()
 		case r == EofRune:
-			return mkToken(TokenEOF, "EOF")
+			return mkToken(tokenEOF, "EOF")
 		case r == '\n':
 			return mkToken(tokenNewline, "\n")
 		case r == '(':

--- a/lisp1_5/parse.go
+++ b/lisp1_5/parse.go
@@ -144,7 +144,7 @@ func (p *Parser) back(tok *token) {
 func (p *Parser) SExpr() *Expr {
 	tok := p.next()
 	switch tok.typ {
-	case TokenEOF:
+	case tokenEOF:
 		return nil
 	case tokenQuote:
 		return p.quote()
@@ -176,7 +176,7 @@ func (p *Parser) quote() *Expr {
 func (p *Parser) List() *Expr {
 	tok := p.next()
 	switch tok.typ {
-	case TokenEOF:
+	case tokenEOF:
 		panic(EOF("eof"))
 	case tokenQuote:
 		return p.quote()

--- a/lisp1_5/toktype_string.go
+++ b/lisp1_5/toktype_string.go
@@ -9,7 +9,7 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[tokenError-0]
-	_ = x[TokenEOF-1]
+	_ = x[tokenEOF-1]
 	_ = x[tokenAtom-2]
 	_ = x[tokenConst-3]
 	_ = x[tokenNumber-4]
@@ -21,9 +21,9 @@ func _() {
 	_ = x[tokenNewline-10]
 }
 
-const _TokType_name = "tokenErrorenEOFtokenAtomtokenConsttokenNumbertokenLpartokenRpartokenDottokenChartokenQuotetokenNewline"
+const _TokType_name = "tokenErrortokenEOFtokenAtomtokenConsttokenNumbertokenLpartokenRpartokenDottokenChartokenQuotetokenNewline"
 
-var _TokType_index = [...]uint8{0, 10, 15, 24, 34, 45, 54, 63, 71, 80, 90, 102}
+var _TokType_index = [...]uint8{0, 10, 18, 27, 37, 48, 57, 66, 74, 83, 93, 105}
 
 func (i TokType) String() string {
 	if i < 0 || i >= TokType(len(_TokType_index)-1) {


### PR DESCRIPTION
In the original code `TokenEOF.String()` would have been `"enEOF"`.